### PR TITLE
fix to Call to 'bind' is ambiguous

### DIFF
--- a/src/ofxEasing.h
+++ b/src/ofxEasing.h
@@ -273,7 +273,7 @@ inline float map(float v, float minIn, float maxIn, float minOut, float maxOut, 
 
 template<typename Function, typename ...Args>
 inline float map(float v, float minIn, float maxIn, float minOut, float maxOut, Function easing, Args... parameters){
-	return map(v, minIn, maxIn, minOut, maxOut, bind(easing, parameters...));
+	return map(v, minIn, maxIn, minOut, maxOut, ofxeasing::bind(easing, parameters...));
 }
 
 inline float map_clamp(float v, float minIn, float maxIn, float minOut, float maxOut, std::function<float(float,float,float,float)> easing){
@@ -283,7 +283,7 @@ inline float map_clamp(float v, float minIn, float maxIn, float minOut, float ma
 
 template<typename Function, typename ...Args>
 inline float map_clamp(float v, float minIn, float maxIn, float minOut, float maxOut, Function easing, Args... parameters){
-	return map_clamp(v, minIn, maxIn, minOut, maxOut, bind(easing, parameters...));
+	return map_clamp(v, minIn, maxIn, minOut, maxOut, ofxeasing::bind(easing, parameters...));
 }
 
 typedef std::function<float(float, float, float, float)> function;


### PR DESCRIPTION
```
// example code
#include "ofxEasing.h"

enum EasingExtra {
    BackIn_s, BackOut_s, BackInOut_s,
    ElasticInPow, ElasticOutPow, ElasticInOutPow,
};

float easing(float v, float minIn, float maxIn, float minOut, float maxOut, EasingExtra ease, float extra) {
    return ofxeasing::map_clamp(v, minIn, maxIn, minOut, maxOut, getFunctionExtra(ease), extra);
}

typedef std::function<float(float, float, float, float, float)> functionExtra;

functionExtra getFunctionExtra(EasingExtra ease) {
    static std::map<EasingExtra, functionExtra> index = {
        {EasingExtra::BackIn_s, ofxeasing::back::easeIn_s},
        {EasingExtra::BackOut_s, ofxeasing::back::easeOut_s},
        {EasingExtra::BackInOut_s, ofxeasing::back::easeInOut_s},
        
        {EasingExtra::ElasticInPow, ofxeasing::elastic::easeInPow},
        {EasingExtra::ElasticOutPow, ofxeasing::elastic::easeOutPow},
        {EasingExtra::ElasticInOutPow, ofxeasing::elastic::easeInOutPow},
    };

    return index[ease];
}
```